### PR TITLE
Use latin `A` and `B` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Here is the standard keyboard for reference:
 
 ```
 |qQ|wW|eE|rR|tT|yY|uU|iI|oO|pP|
- |aΑ|sS|dD|fF|gG|hH|jJ|kK|lL|;:|
-  |zZ|xX|cC|vV|bΒ|nN|mM|,<|.>|/?|
+ |aA|sS|dD|fF|gG|hH|jJ|kK|lL|;:|
+  |zZ|xX|cC|vV|bB|nN|mM|,<|.>|/?|
 ```
 
 (where between each pair of |'s, we specify first the standard character to be bound to, and the second when holding down shift)

--- a/layouts/standard_keyboard.txt
+++ b/layouts/standard_keyboard.txt
@@ -1,3 +1,3 @@
 |qQ|wW|eE|rR|tT|yY|uU|iI|oO|pP|
- |aΑ|sS|dD|fF|gG|hH|jJ|kK|lL|;:|
-  |zZ|xX|cC|vV|bΒ|nN|mM|,<|.>|/?|
+ |aA|sS|dD|fF|gG|hH|jJ|kK|lL|;:|
+  |zZ|xX|cC|vV|bB|nN|mM|,<|.>|/?|


### PR DESCRIPTION
Use latin `A` and `B` in examples, or passwords will not match when using a newly created layout and the standard one :)